### PR TITLE
adds delete all, filter commands, flex opening

### DIFF
--- a/pocket_comm.py
+++ b/pocket_comm.py
@@ -5,6 +5,7 @@ import requests
 import subprocess as sp
 import sys
 import itertools
+from starter_program import OPEN_COMMAND
 
 
 class PocketItem:
@@ -126,7 +127,7 @@ class Pocket:
     def redirect_to_authorization(self, request_token):
         sp.run(
             [
-                "xdg-open",
+                OPEN_COMMAND,
                 (
                     "https://getpocket.com/auth/authorize"
                     f"?request_token={request_token}"

--- a/pocket_prompt.py
+++ b/pocket_prompt.py
@@ -4,15 +4,20 @@ from pocket_comm import PocketItem, Pocket
 from tabulate import tabulate
 import readline
 import subprocess as sp
+from urllib.parse import urlparse
+from starter_program import OPEN_COMMAND
 
 
 class PocketPrompt:
     valid_commands = {
         "v": "[v]iew <index>",
         "d": "[d]elete <index>",
+        "da": "[d]elete [a]ll",
+        ".": "domains",
         "vd": "[vd] <index>",
         "u": "[u]pdate",
-        "f": "[f]ilter",
+        "l": "by [l]ength",
+        "f": "[f]ilter <keyword>",
         "s": "[s]ort",
         "t": "[t]ag",
         "q": "[q]uit",
@@ -45,6 +50,10 @@ class PocketPrompt:
             idx += 1
 
     def display(self):
+        if len(self.items) == 0:
+            print("\n\nNo items found\n\n")
+            return
+
         match self.sort_by:
             case 1:
                 self.sort_by_time_added()
@@ -87,7 +96,49 @@ class PocketPrompt:
         print(lines[0])
         print()
 
-    def prompt_filter(self):
+    def prompt_filter(self, match):
+        self.items = dict(
+            filter(
+                lambda pair: match in pair[1].given_url or match in pair[1].given_title,
+                self.items.items(),
+            )
+        )
+
+    def prompt_domains(self):
+        domains = defaultdict(int)
+        for item in self.items.values():
+            domain = urlparse(item.given_url).hostname
+            domains[domain] += 1
+
+        repeated_domains = {}
+        for domain in domains.keys():
+            if domains[domain] > 1:
+                repeated_domains[domain] = domains[domain]
+
+        while True:
+            try:
+                for domain, count in repeated_domains.items():
+                    print(f"{count}: {domain}")
+                group_idx = int(input("> "))
+                if 1 <= group_idx <= len(groups):
+                    break
+            except ValueError:
+                pass
+
+        min_time_to_read = groups[group_idx - 1] * 5
+        max_time_to_read = (groups[group_idx - 1] + 1) * 5
+
+        self.items = dict(
+            filter(
+                lambda pair: min_time_to_read
+                <= pair[1].time_to_read
+                < max_time_to_read,
+                self.items.items(),
+            )
+        )
+
+
+    def prompt_length(self):
         # show possible groups of 5 minutes increment
         groups: set[int] = set()
         for item in self.items.values():
@@ -140,9 +191,9 @@ class PocketPrompt:
                 continue
             if tokens[0] not in PocketPrompt.valid_commands.keys():
                 continue
-            if tokens[0] in ("q", "u", "f", "s", "t") and len(tokens) != 1:
+            if tokens[0] in ("q", "u", "l", "s", "t") and len(tokens) != 1:
                 continue
-            if tokens[0] in ("v", "d", "vd") and len(tokens) != 2:
+            if tokens[0] in ("v", "d", "vd", "f") and len(tokens) != 2:
                 continue
 
             return tokens
@@ -162,8 +213,19 @@ class PocketPrompt:
                     self.update()
                     self.display()
                     continue
+                case "l":
+                    self.prompt_length()
+                    self.display()
+                    continue
+                case ".":
+                    self.prompt_domains()
+                    self.display()
+                    continue
                 case "f":
-                    self.prompt_filter()
+                    match = tokens[1]
+                    self.update()
+                    if match:
+                        self.prompt_filter(match)
                     self.display()
                     continue
                 case "s":
@@ -172,6 +234,12 @@ class PocketPrompt:
                     continue
                 case "t":
                     self.update_tags()
+                case "da":
+                    for item_id in self.items.keys():
+                        self.pocket.request_delete(item_id)
+                    self.update()
+                    self.display()
+                    continue
                 case _:
                     idx = int(tokens[1])
 
@@ -188,7 +256,7 @@ class PocketPrompt:
                     match cmd:
                         case "v":
                             sp.Popen(
-                                ["xdg-open", self.items[item_id].given_url],
+                                [OPEN_COMMAND, self.items[item_id].given_url],
                                 stdout=sp.DEVNULL,
                                 stderr=sp.DEVNULL,
                             )
@@ -198,7 +266,7 @@ class PocketPrompt:
                             self.display()
                         case "vd":
                             sp.Popen(
-                                ["xdg-open", self.items[item_id].given_url],
+                                [OPEN_COMMAND, self.items[item_id].given_url],
                                 stdout=sp.DEVNULL,
                                 stderr=sp.DEVNULL,
                             )

--- a/pocket_prompt.py
+++ b/pocket_prompt.py
@@ -13,7 +13,7 @@ class PocketPrompt:
         "v": "[v]iew <index>",
         "d": "[d]elete <index>",
         "da": "[d]elete [a]ll",
-        ".": "domains",
+        ".": "[.] domains",
         "vd": "[vd] <index>",
         "u": "[u]pdate",
         "l": "by [l]ength",
@@ -109,33 +109,27 @@ class PocketPrompt:
         for item in self.items.values():
             domain = urlparse(item.given_url).hostname
             domains[domain] += 1
-
-        repeated_domains = {}
-        for domain in domains.keys():
-            if domains[domain] > 1:
-                repeated_domains[domain] = domains[domain]
+        domains = list(domains.items())
 
         while True:
+            for idx, (domain, count) in enumerate(domains, start=1):
+                print(f"{idx}. {count}: {domain}")
             try:
-                for domain, count in repeated_domains.items():
-                    print(f"{count}: {domain}")
-                group_idx = int(input("> "))
-                if 1 <= group_idx <= len(groups):
+                domain_idx = int(input("> "))
+                if 1 <= domain_idx <= len(domains):
+                    filter_domain = domains[domain_idx - 1][0]
                     break
+                raise ValueError
             except ValueError:
+                print("Invalid index\n")
                 pass
-
-        min_time_to_read = groups[group_idx - 1] * 5
-        max_time_to_read = (groups[group_idx - 1] + 1) * 5
 
         self.items = dict(
             filter(
-                lambda pair: min_time_to_read
-                <= pair[1].time_to_read
-                < max_time_to_read,
+                lambda pair: urlparse(pair[1].given_url).hostname ==
+                filter_domain,
                 self.items.items(),
-            )
-        )
+            ))
 
 
     def prompt_length(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+tabulate

--- a/starter_program.py
+++ b/starter_program.py
@@ -1,0 +1,11 @@
+import sys
+
+
+if sys.platform.startswith("linux"):
+    OPEN_COMMAND = "xdg-open"
+elif sys.platform.startswith("windows"):
+    OPEN_COMMAND = "start"
+elif sys.platform == "darwin":
+    OPEN_COMMAND = "open"
+else:
+    raise NotImplemented(f"We do not know how to open URLs in {sys.platform} platform")


### PR DESCRIPTION
Hi Christoph, awesome package.
I wanted to clean up my list, which accumulated a thousand items since 2015 and it helped a lot.
For that, I added a couple of commands:
* `da`: delete all — from a list (like after filtering);
* `f`: filter (moved “by length” to `[l]ength`);
* `.`: to group by domains, to find clusters of URLs;

Also now it deals with empty lists.

Also made the `open` command multi-platform.